### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,16 @@
 ## Prerequisites
 
 1. Have docker and docker-compose (`1.29.2`)
-2. Have cargo-contract (`3.2.0`) installed:
+2. Have `nightly-2024-02-16` Rust toolchain installed:
 
 ```bash
-cargo +nightly-2024-02-04 install cargo-contract --vers 3.2.0 --force --locked
+rustup toolchain install nightly-2024-02-16
+rustup component add rust-src --toolchain nightly-2024-02-16-x86_64-unknown-linux-gnu
+```
+3. Have cargo-contract (`3.2.0`) installed:
+
+```bash
+cargo +nightly-2024-02-16 install cargo-contract --vers 3.2.0 --force
 ```
 
 Install [polkadot{.js}](https://polkadot.js.org/extension/) extension.
@@ -23,12 +29,13 @@ Add these two accounts:
 ## Running a node locally
 
 ```bash
+# You might be asked to login into docker with `docker login`.
 make devnode
 ```
 
 ## Contracts
 
-To compile:
+To compile all contracts:
 
 ```bash
 make compile
@@ -37,10 +44,12 @@ make compile
 To deploy e.g. `escrow` contract:
 
 ```bash
-deploy escrow
+make deploy-escrow
 ```
 
-Deployed contracts write their addresses to the `addresses.json` file in the root directory. You can copy the address and use it in the [https://contracts-ui.substrate.io/contract](https://contracts-ui.substrate.io/contract)
+Deployed contracts write their addresses to the `addresses.json` file in the root directory.
+You can copy the address and use it in the [contracts-ui explorer](https://contracts-ui.substrate.io/address-lookup).
+Contract metadata can be found in a corresponding `target` directory, e.g. [escrow/target/ink/escrow.contract](escrow/target/ink/escrow.contract).
 
 ### Testnet
 


### PR DESCRIPTION
1. unify toolchain across `README.md` and `rust-toolchain.toml`
2. remove `--locked` flag when installing cc (`ahash` was yanked)
3. note on `docker login`
4. tiny changes to `README.md`